### PR TITLE
feat: ability to accept rejected applications 

### DIFF
--- a/apps/admin-dashboard/app/routes/_dashboard.applications.$id.accept.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.$id.accept.tsx
@@ -105,7 +105,7 @@ export default function ApplicationPage() {
         <Form.ErrorMessage>{error}</Form.ErrorMessage>
 
         <Button.Group flexDirection="row-reverse">
-          <Button type="submit">Accept Application</Button>
+          <Button type="submit">Confirm</Button>
 
           <Button onClick={onBack} type="button" variant="secondary">
             Back

--- a/apps/admin-dashboard/app/routes/_dashboard.applications.$id.accept.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.$id.accept.tsx
@@ -1,0 +1,117 @@
+import {
+  type ActionFunctionArgs,
+  json,
+  type LoaderFunctionArgs,
+  redirect,
+} from '@remix-run/node';
+import {
+  Form as RemixForm,
+  useActionData,
+  useLoaderData,
+  useNavigate,
+} from '@remix-run/react';
+
+import { Button, Form, Modal } from '@oyster/ui';
+
+import { Route } from '../shared/constants';
+import { acceptApplication, getApplication } from '../shared/core.server';
+import {
+  commitSession,
+  ensureUserAuthenticated,
+  toast,
+  user,
+} from '../shared/session.server';
+
+export async function loader({ params, request }: LoaderFunctionArgs) {
+  await ensureUserAuthenticated(request, {
+    allowAmbassador: true,
+  });
+
+  const application = await getApplication(params.id as string, [
+    'applications.firstName',
+    'applications.lastName',
+  ]);
+
+  if (!application) {
+    throw new Response(null, { status: 404 });
+  }
+
+  return json({
+    application,
+  });
+}
+
+export async function action({ params, request }: ActionFunctionArgs) {
+  const session = await ensureUserAuthenticated(request, {
+    allowAmbassador: true,
+  });
+
+  const adminId = user(session);
+
+  try {
+    await acceptApplication(params.id as string, adminId);
+
+    toast(session, {
+      message: 'Application has been accepted.',
+      type: 'success',
+    });
+
+    return redirect(Route.APPLICATIONS, {
+      headers: {
+        'Set-Cookie': await commitSession(session),
+      },
+    });
+  } catch (e) {
+    if ((e as Error).message.includes('FK_7b8cdcaabacb80df1ed8f7dbbea')) {
+      return json({
+        error: "You don't have the permissions to accept an application",
+      });
+    } else {
+      return json({
+        error: (e as Error).message,
+      });
+    }
+  }
+}
+
+export default function ApplicationPage() {
+  const { application } = useLoaderData<typeof loader>();
+  const { error } = useActionData<typeof action>() || {};
+
+  const navigate = useNavigate();
+
+  function onBack() {
+    navigate(-1);
+  }
+
+  function onClose() {
+    navigate(-1);
+  }
+
+  return (
+    <Modal onClose={onClose}>
+      <Modal.Header>
+        <Modal.Title>Accept Application</Modal.Title>
+        <Modal.CloseButton />
+      </Modal.Header>
+
+      <Modal.Description>
+        Just confirming - do you want to accept the application of{' '}
+        {application.firstName} {application.lastName}? This application was
+        previously rejected.
+      </Modal.Description>
+
+      <RemixForm className="form" method="post">
+        <Form.ErrorMessage>{error}</Form.ErrorMessage>
+
+        <Button.Group flexDirection="row-reverse">
+          <Button type="submit">Accept Application</Button>
+
+          <Button onClick={onBack} type="button" variant="secondary">
+            Back
+          </Button>
+        </Button.Group>
+      </RemixForm>
+    </Modal>
+  );
+}

--- a/apps/admin-dashboard/app/routes/_dashboard.applications.tsx
+++ b/apps/admin-dashboard/app/routes/_dashboard.applications.tsx
@@ -201,6 +201,9 @@ function ApplicationsTable() {
       {...(searchParams.status === 'pending' && {
         Dropdown: ApplicationDropdown,
       })}
+      {...(searchParams.status === 'rejected' && {
+        Dropdown: ApplicationDropdown,
+      })}
     />
   );
 }
@@ -225,6 +228,8 @@ function ApplicationDropdown({ id }: ApplicationInView) {
 
   const { search } = useLocation();
 
+  const [searchParams] = useSearchParams(ApplicationsSearchParams);
+
   function onClose() {
     setOpen(false);
   }
@@ -238,18 +243,34 @@ function ApplicationDropdown({ id }: ApplicationInView) {
       {open && (
         <Table.Dropdown>
           <Dropdown.List>
-            <Dropdown.Item>
-              <Link
-                to={{
-                  pathname: generatePath(Route.UPDATE_APPLICATION_EMAIL, {
-                    id,
-                  }),
-                  search,
-                }}
-              >
-                <Edit /> Update Email
-              </Link>
-            </Dropdown.Item>
+            {searchParams.status === 'pending' && (
+              <Dropdown.Item>
+                <Link
+                  to={{
+                    pathname: generatePath(Route.UPDATE_APPLICATION_EMAIL, {
+                      id,
+                    }),
+                    search,
+                  }}
+                >
+                  <Edit /> Update Email
+                </Link>
+              </Dropdown.Item>
+            )}
+            {searchParams.status === 'rejected' && (
+              <Dropdown.Item>
+                <Link
+                  to={{
+                    pathname: generatePath(Route.ACCEPT_APPLICATION, {
+                      id,
+                    }),
+                    search,
+                  }}
+                >
+                  <Edit /> Accept Application
+                </Link>
+              </Dropdown.Item>
+            )}
           </Dropdown.List>
         </Table.Dropdown>
       )}

--- a/apps/admin-dashboard/app/shared/constants.ts
+++ b/apps/admin-dashboard/app/shared/constants.ts
@@ -8,6 +8,7 @@ export const Route = {
   APPLICATION: '/applications/:id',
   APPLICATIONS: '/applications',
   UPDATE_APPLICATION_EMAIL: '/applications/:id/email',
+  ACCEPT_APPLICATION: '/applications/:id/accept',
 
   // Bull
 


### PR DESCRIPTION
## Description ✏️
Need to fix CSS so that dropdown appears within window. (It may be worth creating a separate issue for this)

Unable to test functionality of accepting application. It seems this is because I don't have adminID access. 

- [X] As an admin, when I filter for rejected applications, I should see a menu button appear at the end of each application row.
- [X] As an admin, when I click the "Accept Application" menu button, a confirmation modal should pop up.
- [] As an admin, when the confirmation modal pops up and I click confirm, the member should be accepted.

## Type of Change 🐞

- [x] Feature - A non-breaking change which adds functionality.
- [ ] Fix - A non-breaking change which fixes an issue.
- [ ] Refactor - A change that neither fixes a bug nor adds a feature.
- [ ] Documentation - A change only to in-code or markdown documentation.
- [ ] Tests - A change that adds missing unit/integration tests.
- [ ] Chore - A change that is likely none of the above.

## Checklist ✅

- [ ] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
- [ ] I have added/updated any relevant documentation (if applicable).
